### PR TITLE
Add `fork:true` to code search

### DIFF
--- a/find_datalad_repos/github.py
+++ b/find_datalad_repos/github.py
@@ -101,7 +101,7 @@ class GHDataladSearcher(Client):
 
     def search_dataset_repos(self) -> Iterator[GHRepo]:
         log.info("Searching for repositories with .datalad/config files")
-        for hit in self.search("code", "path:.datalad filename:config"):
+        for hit in self.search("code", "path:.datalad filename:config fork:true"):
             repo = GHRepo.from_repository(hit["repository"])
             log.info("Found %s", repo.name)
             yield repo


### PR DESCRIPTION
Closes #27.

For the record, when I tried adding `fork:true` to a commit search (the other GitHub search endpoint we use) via the REST API, I got zero results, so I assume it's invalid for searching commits.