### PR TITLE
Drop 3.8 and 3.9 as a supported Python version

### DIFF
--- a/.github/workflows/update-gin.yml
+++ b/.github/workflows/update-gin.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.8'
+          python-version: '^3.9'
 
       - name: Set up environment
         run: |

--- a/.github/workflows/update-gin.yml
+++ b/.github/workflows/update-gin.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.9'
+          python-version: '^3.10'
 
       - name: Set up environment
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.8'
+          python-version: '^3.9'
 
       - name: Set up environment
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.9'
+          python-version: '^3.10'
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
See individual commits for the rationale.