### PR TITLE
Revert "Set GIN token in a simpler way"

### DIFF
--- a/src/find_datalad_repos/gin.py
+++ b/src/find_datalad_repos/gin.py
@@ -61,7 +61,9 @@ class GINSearcher(Client, Searcher[GINRepo]):
             user_agent=USER_AGENT,
             accept=None,
             api_version=None,
-            token=token,
+            # Passing `token` directly to ghreq results in an Authorization
+            # header of "Bearer {token}", which GIN doesn't seem to support.
+            headers={"Authorization": f"token {token}"},
             # Don't retry on 500's until
             # <https://github.com/G-Node/gogs/issues/148> is resolved
             retry_config=RetryConfig(retry_statuses=range(501, 600)),


### PR DESCRIPTION
This reverts commit 29016a78642891d2a04ebfa198a8b9a94eb03212.

Turns out GIN doesn't actually support "Bearer".