### PR TITLE
Fix mypy typing error in get_metavar method signature

### DIFF
--- a/src/find_datalad_repos/__main__.py
+++ b/src/find_datalad_repos/__main__.py
@@ -35,7 +35,7 @@ class RepoHostSet(click.ParamType):
                     self.fail(f"{value!r}: invalid item {v!r}", param, ctx)
         return selected
 
-    def get_metavar(self, _param: click.Parameter) -> str:
+    def get_metavar(self, _param: click.Parameter, _ctx: click.Context) -> str:
         return "[all," + ",".join(v.value for v in RepoHost) + "]"
 
 


### PR DESCRIPTION
The get_metavar method in RepoHostSet class had an incompatible [signature with its supertype ParamType](https://click.palletsprojects.com/en/stable/api/#click.Choice.get_metavar). Updated to match the expected signature by adding the missing 'ctx' parameter.

Also prefixed unused parameters with underscore to satisfy linter.

This fixes the 'tox -e typing' failure.

🤖 Generated with [Claude Code](https://claude.ai/code)